### PR TITLE
Allows for IP targets in NLB

### DIFF
--- a/loadbalancer.config.yaml
+++ b/loadbalancer.config.yaml
@@ -46,3 +46,51 @@ securityGroups:
       ips:
         - public
         - internal
+
+#### Example configuration for NLB. Assumes component has been passed parameter named "AuroraMysqlIp"
+
+#loadbalancer_type: network
+#loadbalancer_scheme: public
+#loadbalancer_attributes:
+#  idle_timeout.timeout_seconds:
+#loadbalancer_tags:
+#  Name: aurora-proxy
+#
+#records:
+#  - dbproxy
+#
+#targetgroups:
+#  default:
+#    protocol: tcp
+#    port: 3306
+#    type: ip
+#    tags:
+#      Name: MySQL-TCP
+#    healthcheck:
+#      HealthCheckPort: "traffic-port"
+#      protocol: TCP
+#    target_ips:
+#      - ip:
+#          Ref: AuroraMysqlIp
+#        port: 3306
+#
+#listeners:
+#  http:
+#  mysql:
+#    port: 3306
+#    protocol: tcp
+#    default_targetgroup: default
+#
+#
+#
+#ip_blocks:
+#  public:
+#  - 0.0.0.0/0
+#securityGroups:
+#  loadbalancer:
+#  - rules:
+#    - IpProtocol: tcp
+#      FromPort: 3306
+#      ToPort: 3306
+#    ips:
+#      - public


### PR DESCRIPTION
- Allow hiding of default attributes by giving them `nil` value
- Allow hiding of default listeners by giving them `nil` value
- Allow adding IP targets for NLB

Example configuration for NLB. Assumes component has been passed parameter named `AuroraMysqlIp`

```
loadbalancer_type: network
loadbalancer_scheme: public
loadbalancer_attributes:
  idle_timeout.timeout_seconds:
loadbalancer_tags:
  Name: aurora-proxy

records:
  - dbproxy

targetgroups:
  default:
    protocol: tcp
    port: 3306
    type: ip
    tags:
      Name: MySQL-TCP
    healthcheck:
      HealthCheckPort: "traffic-port"
      protocol: TCP
    target_ips:
      - ip:
          Ref: AuroraMysqlIp
        port: 3306

listeners:
  http:
  mysql:
    port: 3306
    protocol: tcp
    default_targetgroup: default



ip_blocks:
  public:
  - 0.0.0.0/0
securityGroups:
  loadbalancer:
  - rules:
    - IpProtocol: tcp
      FromPort: 3306
      ToPort: 3306
    ips:
      - public

```