### PR TITLE
Add ability to add redirects rules to a load balancer.

### DIFF
--- a/loadbalancer.cfndsl.rb
+++ b/loadbalancer.cfndsl.rb
@@ -125,6 +125,7 @@ CloudFormation do
     listener['rules'].each do |rule|
 
       listener_conditions = []
+      actions = []
 
       if rule.key?("path")
         listener_conditions << { Field: "path-pattern", Values: [ rule["path"] ] }
@@ -140,8 +141,16 @@ CloudFormation do
         listener_conditions << { Field: "host-header", Values: hosts }
       end
 
+      if rule.key?("targetgroup")
+        actions << { Type: "forward", TargetGroupArn: Ref("#{rule['targetgroup']}TargetGroup") }
+      end
+
+      if rule.key?("redirect")
+        actions << { Type: "redirect", RedirectConfig: rule['redirect'] }
+      end
+
       ElasticLoadBalancingV2_ListenerRule("#{listener_name}Rule#{rule['priority']}") do
-        Actions [{ Type: "forward", TargetGroupArn: Ref("#{rule['targetgroup']}TargetGroup") }]
+        Actions actions
         Conditions listener_conditions
         ListenerArn Ref("#{listener_name}Listener")
         Priority rule['priority'].to_i

--- a/loadbalancer.config.yaml
+++ b/loadbalancer.config.yaml
@@ -43,6 +43,15 @@ listeners:
     #       Fn::Join: [ '.', [ 'api', 'example', 'com' ] ]
     #     priority: 300
     #     targetgroup: api
+    #   - host: *
+    #     priority: 400
+    #     redirect:
+    #       Host: '#{host}'
+    #       Path: '/#{path}'
+    #       Port: '443'
+    #       Protocol: 'HTTPS'
+    #       Query: '#{query}'
+    #       StatusCode: 'HTTP_301'
   # https:
   #   port: 443
   #   protocol: https


### PR DESCRIPTION
The added example in the `loadbalancer.config.yaml` shows how to use the redirect in order to add a HTTP to HTTPS redirect. 